### PR TITLE
Duplicate incoming messages fix

### DIFF
--- a/Q-municate/src/main/java/com/quickblox/qmunicate/qb/helpers/QBMultiChatHelper.java
+++ b/Q-municate/src/main/java/com/quickblox/qmunicate/qb/helpers/QBMultiChatHelper.java
@@ -3,7 +3,6 @@ package com.quickblox.qmunicate.qb.helpers;
 import android.content.Context;
 import android.os.Bundle;
 import android.text.TextUtils;
-import android.util.Log;
 
 import com.quickblox.internal.core.exception.QBResponseException;
 import com.quickblox.internal.module.custom.request.QBCustomObjectUpdateBuilder;
@@ -268,7 +267,7 @@ public class QBMultiChatHelper extends BaseChatHelper {
             }
             // end of todo
 
-            saveMessageToCache(new DialogMessageCache(messageId, dialogId, chatMessage.getSenderId(),
+            saveMessageToCache(new DialogMessageCache(chatMessage.getProperty("message_id"), dialogId, chatMessage.getSenderId(),
                     chatMessage.getBody(), attachUrl, time, isRead));
 
             if (!chatMessage.getSenderId().equals(chatCreator.getId())) {

--- a/Q-municate/src/main/java/com/quickblox/qmunicate/qb/helpers/QBPrivateChatHelper.java
+++ b/Q-municate/src/main/java/com/quickblox/qmunicate/qb/helpers/QBPrivateChatHelper.java
@@ -25,7 +25,6 @@ import com.quickblox.qmunicate.utils.DateUtils;
 import com.quickblox.qmunicate.utils.ErrorUtils;
 
 import java.io.File;
-import java.util.List;
 
 public class QBPrivateChatHelper extends BaseChatHelper implements QBPrivateChatManagerListener {
 
@@ -170,7 +169,7 @@ public class QBPrivateChatHelper extends BaseChatHelper implements QBPrivateChat
         time = Long.parseLong(chatMessage.getProperty(PROPERTY_DATE_SENT));
         attachUrl = ChatUtils.getAttachUrlIfExists(chatMessage);
         String dialogId = chatMessage.getProperty(ChatUtils.PROPERTY_DIALOG_ID);
-        saveMessageToCache(new DialogMessageCache(messageId, dialogId, chatMessage.getSenderId(), chatMessage.getBody(),
+        saveMessageToCache(new DialogMessageCache(chatMessage.getProperty("message_id"), dialogId, chatMessage.getSenderId(), chatMessage.getBody(),
                 attachUrl, time, false));
         notifyMessageReceived(chatMessage, friend, dialogId);
     }


### PR DESCRIPTION
Had issue with receiving duplicate messages.  Appeared to be issue with not being able to receive message_id.   Made minimal changes to correct issue.
